### PR TITLE
Fixed scipy build due to pythran

### DIFF
--- a/Dockerfile.ppc64le.ubi
+++ b/Dockerfile.ppc64le.ubi
@@ -198,7 +198,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,from=numa-builder,source=/numactl/,target=/numactl/,rw \
     --mount=type=bind,src=.,dst=/src/,rw \
     source /opt/rh/gcc-toolset-13/enable && export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 && \
-    uv pip install /opencvwheels/*.whl /arrowwheels/*.whl /torchwheels/*.whl && \
+    uv pip install pythran /opencvwheels/*.whl /arrowwheels/*.whl /torchwheels/*.whl && \
     sed -i -e 's/.*torch.*//g' /src/pyproject.toml /src/requirements/*.txt && \
     uv pip install pandas /hf_wheels/*.whl && \
     make -C /numactl install && \


### PR DESCRIPTION
Another attempt to fix the build - this time scipy 1.15.3 failed to build from source due to pythran not being found
@riprasad FYI.